### PR TITLE
Fix typo in hadnleIP6PairAgg

### DIFF
--- a/cmd/texporter/tcollector.go
+++ b/cmd/texporter/tcollector.go
@@ -251,7 +251,7 @@ func hadnleIP6PairAgg(wg *sync.WaitGroup, c *trafficmonCollector, ch chan<- prom
 	}
 
 	if key.Flags&FLAG_DST_I == FLAG_DST_I {
-		dstIdx := binary.LittleEndian.Uint32(key.Addrs.Src.In6U.U6Addr8[0:4])
+		dstIdx := binary.LittleEndian.Uint32(key.Addrs.Dst.In6U.U6Addr8[0:4])
 		ipDst = IpRanges[dstIdx].Name
 	} else {
 		ipDst = netip.AddrFrom16(dst).String()


### PR DESCRIPTION
Fix typo preventing counting of IPv6 packets belonging to named ranges.